### PR TITLE
feat: update bytes dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-buf-pool"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Chris Nixon <chris.nixon@sigma.me.uk>"]
 edition = "2018"
 
@@ -10,4 +10,4 @@ edition = "2018"
 async-channel = "1.5"
 thiserror = "1.0"
 
-bytes = "0.5"
+bytes = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,8 +220,8 @@ where
         self.data.remaining()
     }
 
-    fn bytes(&self) -> &[u8] {
-        self.data.bytes()
+    fn chunk(&self) -> &[u8] {
+        self.data.chunk()
     }
 
     fn advance(&mut self, cnt: usize) {


### PR DESCRIPTION
This allows downstream to use Bytes 1.0 types in the pool and have Buf implemented, which means it can be used with hyper 0.14 and therefor tokio 1.0